### PR TITLE
Add ToxMCP Suite to registry

### DIFF
--- a/servers/ToxMCP-toxmcp/meta.yaml
+++ b/servers/ToxMCP-toxmcp/meta.yaml
@@ -1,0 +1,42 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/ToxMCP/toxmcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: ToxMCP/toxmcp
+
+name: ToxMCP Suite
+
+description: >
+  Guardrailed, auditable agentic workflows for computational toxicology delivered via the Model Context Protocol (MCP), with modules for CompTox, ADMETlab, AOP, O-QT, and PBPK workflows.
+
+codeRepository: https://github.com/ToxMCP/toxmcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://github.com/ToxMCP/toxmcp/tree/main/docs
+  name: ToxMCP Docs
+
+maintainer:
+  - "@type": Person
+    name: Ivo Djidrovski
+    identifier: Brhii56
+    url: https://github.com/Brhii56
+  - "@type": Organization
+    name: ToxMCP Maintainers
+    identifier: ToxMCP
+    url: https://github.com/ToxMCP
+
+license: https://spdx.org/licenses/Apache-2.0.html
+
+applicationCategory: HealthApplication
+
+datePublished: "2026-02-16"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python


### PR DESCRIPTION
Name: ToxMCP Suite

Description: Guardrailed, auditable agentic workflows for computational toxicology delivered via the Model Context Protocol (MCP), with modules for CompTox, ADMETlab, AOP, O-QT, and PBPK workflows.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`
- [ ] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: The MCP server provides specific tools for biomedical research or clinical activities (computational toxicology workflows and integrations)
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [ ] **Free Academic Usage**: The services exposed through the MCP server are free for academic research
- [x] **Non-Duplication**: This is not a fully duplicate effort of an existing BioContextAI registry MCP server (umbrella suite covering multiple toxicology MCP modules)
- [ ] **MCP Compliance**: The server properly implements the Model Context Protocol specification
- [ ] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: The project is not abandoned
- [ ] **Functionality Testing**: All exposed tools and resources have been tested and function as expected (manual or unit tests)
