### PR TITLE
Add cxg-census-mcp to registry

### DIFF
--- a/servers/MaxMLang-cxg-census-mcp/mcp.json
+++ b/servers/MaxMLang-cxg-census-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "MaxMLang/cxg-census-mcp": {
+      "command": "uvx",
+      "args": ["--from", "cxg-census-mcp[census]", "cxg-census-mcp"]
+    }
+  }
+}

--- a/servers/MaxMLang-cxg-census-mcp/meta.yaml
+++ b/servers/MaxMLang-cxg-census-mcp/meta.yaml
@@ -1,0 +1,46 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/MaxMLang/cxg-census-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: MaxMLang/cxg-census-mcp
+
+name: cxg-census-mcp
+
+description: >
+  MCP server for CZ CELLxGENE Discover Census. Single-cell RNA-seq queries, ontology-aware (CL, UBERON, EFO), provenance-tracked. For Claude, Cursor, MCP clients.
+
+codeRepository: https://github.com/MaxMLang/cxg-census-mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://github.com/MaxMLang/cxg-census-mcp#readme
+  name: Documentation
+
+maintainer:
+  - "@type": Person
+    name: Max
+    identifier: MaxMLang
+    url: https://github.com/MaxMLang
+
+license: https://spdx.org/licenses/MIT.html
+
+applicationCategory: HealthApplication
+
+keywords:
+  - bioinformatics
+  - computational-biology
+  - single-cell
+  - single-cell-rna-seq
+  - cellxgene
+  - cellxgene-census
+
+datePublished: "2026-04-22"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python


### PR DESCRIPTION
Name: cxg-census-mcp

Description: Community MCP server for the CZ CELLxGENE Discover Census single-cell atlas. Ontology-aware queries (CL / UBERON / MONDO / EFO), provenance + CC BY 4.0 attribution on every response, cost caps, snippet escape hatch. For Claude, Cursor, MCP clients. Independent project, unaffiliated with CZI.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`  `https://github.com/MaxMLang/cxg-census-mcp`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: The MCP server provides specific tools for biomedical research or clinical activities, it exposes 13 tools over the CZ CELLxGENE Discover Census so LLM agents can ask questions like "compare immune cell composition of healthy vs COVID-19 human lung" in plain English. Single-cell counts, expression aggregation, ontology resolution (CL/UBERON/MONDO/EFO), dataset listing, etc. Research / exploration only, not a clinical or diagnostic instrument (stated in README + LICENSE).
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema:  MIT
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [x] **Free Academic Usage**: The services exposed through the MCP server are free for academic research, fully free; MIT-licensed code, queries the public CZ CELLxGENE Census (CC BY 4.0) and the public EBI OLS4 API; no paid tier, no API keys, no telemetry
- [x] **Non-Duplication**: This is not a fully duplicate effort of an existing BioContextAI registry MCP server, to my knowledge no other registry entry exposes the CZ CELLxGENE Discover Census via MCP. Distinct from generic genomics / EBI tools in that it speaks SOMA against the Census directly, with built-in ontology resolution and schema-drift handling.
- [x] **MCP Compliance**: The server properly implements the Model Context Protocol specification, built on the official `mcp` Python SDK (>= 1.2.0); implements tools, resources, prompts, progress, and cancellation; verified end-to-end with a stdio `initialize` + `tools/list` + `tools/call` smoke test.
- [x] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: The project is not abandoned, published this week (v0.1.1 on PyPI), Dependabot + CI on every push, scheduled live-smoke + ontology/facet refresh workflows
- [x] **Functionality Testing**: All exposed tools and resources have been tested and function as expected, 162 unit + integration tests passing in CI; every one of the 13 tools has at least one integration smoke test; manual end-to-end MCP round-trip verified against the published PyPI artifact