### PR TITLE
Add DisPhaseDB MCP Server to registry

### DIFF
--- a/servers/bioinformatics-fil-disphase-mcp/mcp.json
+++ b/servers/bioinformatics-fil-disphase-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "bioinformatics-fil/disphase-mcp": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://mcp.disphasedb.leloir.org.ar/mcp"]
+    }
+  }
+}

--- a/servers/bioinformatics-fil-disphase-mcp/meta.yaml
+++ b/servers/bioinformatics-fil-disphase-mcp/meta.yaml
@@ -1,0 +1,50 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://gitlab.com/bioinformatics-fil/disphase-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: bioinformatics-fil/disphase-mcp
+
+name: DisPhaseDB MCP Server
+
+description: >
+  DisPhaseDB MCP enables AI assistants to directly access biologically data of proteins involved in liquid–liquid phase separation (LLPS), including disease-associated mutations, functional regions and condensate associations.
+
+codeRepository: https://gitlab.com/bioinformatics-fil/disphase-mcp
+
+url: https://mcp.disphasedb.leloir.org.ar/mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://gitlab.com/bioinformatics-fil/disphase-mcp#readme
+  name: Documentation
+
+maintainer:
+  - "@type": Organization
+    name: Bioinformatics Unit, Fundación Instituto Leloir
+    identifier: bioinformatics-fil
+    url: https://gitlab.com/bioinformatics-fil
+
+license: https://spdx.org/licenses/AGPL-3.0-only.html
+
+applicationCategory: ReferenceApplication
+
+keywords:
+  - Dataset
+  - Liquid-liquid phase separation
+  - Disease-associated mutations
+  - Protein aggregation
+  - Disordered proteins
+
+datePublished: "2026-05-08"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - DisPhaseDB


### PR DESCRIPTION
Name: DisPhaseDB MCP Server

Description: DisPhaseDB MCP enables AI assistants to directly access biologically data of proteins involved in liquid–liquid phase separation (LLPS), including disease-associated mutations, functional regions and condensate associations.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: The MCP server provides specific tools for biomedical research by enabling structured access to DisPhaseDB data on LLPS-related proteins, disease-associated mutations, functional protein regions, and biomolecular condensate annotations. It supports research into how mutations in phase-separating proteins may contribute to human disease.
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [x] **Free Academic Usage**: The services exposed through the MCP server are free for academic research
- [x] **Non-Duplication**: This is not a fully duplicate effort of an existing BioContextAI registry MCP server (if similar to another server, please explain the unique aspects)
- [x] **MCP Compliance**: The server properly implements the Model Context Protocol specification
- [x] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: The project is not abandoned
- [x] **Functionality Testing**: All exposed tools and resources have been tested and function as expected (manual or unit tests)