### PR TITLE
Add Data Aggregator MCP (musharna/data-aggregator-mcp)

### DIFF
--- a/servers/musharna-data-aggregator-mcp/mcp.json
+++ b/servers/musharna-data-aggregator-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "musharna/data-aggregator-mcp": {
+      "command": "uvx",
+      "args": ["data-aggregator-mcp"]
+    }
+  }
+}

--- a/servers/musharna-data-aggregator-mcp/meta.yaml
+++ b/servers/musharna-data-aggregator-mcp/meta.yaml
@@ -1,0 +1,67 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/musharna/data-aggregator-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: musharna/data-aggregator-mcp
+
+name: Data Aggregator MCP
+
+description: >
+  A Model Context Protocol server that unifies discovery and retrieval of research datasets across
+  Zenodo, DataCite (Dryad / Figshare / Dataverse / OSF), NCBI omics archives (GEO, SRA, BioProject),
+  and the biomedical literature (PubMed, OpenAIRE) behind a single normalized DataResource model.
+  It deduplicates results by DOI, expands organism queries with NCBI Taxonomy synonyms, bridges
+  papers to the omics datasets they produced (e.g. PubMed to GEO / SRA / BioProject), resolves
+  citations and open-access full text, and fetches files to disk with md5 checksum verification.
+  This lets biomedical AI agents find and download sequencing data, supplementary files, and
+  literature from one interface.
+
+codeRepository: https://github.com/musharna/data-aggregator-mcp
+
+url: https://pypi.org/project/data-aggregator-mcp/
+
+softwareHelp:
+  "@type": CreativeWork
+  name: README and usage documentation
+  url: https://github.com/musharna/data-aggregator-mcp#readme
+
+maintainer:
+  - "@type": Person
+    name: musharna
+    identifier: musharna
+    url: https://github.com/musharna
+
+license: https://spdx.org/licenses/MIT.html
+
+applicationCategory: ReferenceApplication
+
+keywords:
+  - datasets
+  - zenodo
+  - datacite
+  - ncbi
+  - sra
+  - geo
+  - pubmed
+  - omics
+  - bioinformatics
+  - research-data
+
+datePublished: "2026-05-30"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - Federated dataset search across Zenodo, DataCite, NCBI GEO/SRA/BioProject, PubMed, and OpenAIRE
+  - DOI-based deduplication into a single normalized DataResource model
+  - NCBI Taxonomy synonym expansion for organism-scoped queries
+  - Paper-to-data linking (PubMed / OpenAIRE to GEO / SRA / BioProject / DataCite)
+  - Checksum-verified file fetch with archive extraction and HTML-integrity guards
+  - Citation rendering and open-access full-text retrieval (EuropePMC, Unpaywall)


### PR DESCRIPTION
Name: Data Aggregator MCP

Description: A Model Context Protocol server that unifies discovery and checksum-verified retrieval of research datasets across Zenodo, DataCite (Dryad/Figshare/Dataverse/OSF), NCBI omics archives (GEO, SRA, BioProject), and the biomedical literature (PubMed, OpenAIRE) behind one normalized DataResource model.

Adds `servers/musharna-data-aggregator-mcp/meta.yaml`.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>` (`https://github.com/musharna/data-aggregator-mcp`)
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. Validated with `jsonschema` against the repo's `schema.json`.
- [x] **Repository Access**: The source code repository URL is publicly accessible (https://github.com/musharna/data-aggregator-mcp)
- [x] **Documentation Access**: The documentation URL is publicly accessible (README at the repo root)
- [x] **Biomedical Relevance**: Provides unified discovery and download of biomedical datasets from NCBI GEO / SRA / BioProject and biomedical literature from PubMed / OpenAIRE (plus general DOI archives), with NCBI-Taxonomy organism normalization and paper→data bridging — letting agents locate and fetch sequencing data, supplementary files, and open-access full text for biomedical research in one interface.
- [x] **Open Source License**: MIT (https://spdx.org/licenses/MIT.html)
- [x] **Search Discoverability**: Keywords cover datasets, zenodo, datacite, ncbi, sra, geo, pubmed, omics, bioinformatics, research-data.
- [x] **Free Academic Usage**: All wired sources are free public APIs (Zenodo, DataCite, NCBI E-utilities/ENA, EuropePMC, OpenAIRE); the server adds no paywall.
- [x] **Non-Duplication**: No existing registry server federates Zenodo + DataCite + NCBI omics + literature behind one normalized model with DOI dedup and paper→data bridging; existing entries wrap a single source.
- [x] **MCP Compliance**: Implements the MCP spec (stdio transport); published to the official MCP registry as `io.github.musharna/data-aggregator-mcp` and on PyPI as `data-aggregator-mcp`.
- [x] **Installation Instructions**: `uvx data-aggregator-mcp` / `pip install data-aggregator-mcp`; client config documented in the README.
- [x] **Maintained**: Actively maintained; released v0.11.0 (2026-05-30).
- [x] **Functionality Testing**: Unit test suite (245 passing) plus live-API probes (`DATA_AGGREGATOR_MCP_LIVE=1`).
