### PR TITLE
Add Plant Genomics MCP (musharna/plant-genomics-mcp)

### DIFF
--- a/servers/musharna-plant-genomics-mcp/mcp.json
+++ b/servers/musharna-plant-genomics-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "musharna/plant-genomics-mcp": {
+      "command": "uvx",
+      "args": ["plant-genomics-mcp"]
+    }
+  }
+}

--- a/servers/musharna-plant-genomics-mcp/meta.yaml
+++ b/servers/musharna-plant-genomics-mcp/meta.yaml
@@ -1,0 +1,66 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/musharna/plant-genomics-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: musharna/plant-genomics-mcp
+
+name: Plant Genomics MCP
+
+description: >
+  A Model Context Protocol server providing 32 tools for plant-genomics locus lookup across 11
+  free public backends: Ensembl Plants, Phytozome BioMart, UniProtKB, Europe PMC, QuickGO,
+  NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, and the Bio-Analytic Resource for Plant Biology.
+  Tools take a TAIR-style locus (e.g. AT1G01010) plus an optional organism (slug, scientific name,
+  common name, or NCBI taxid) and return gene metadata, protein and functional annotation (GO,
+  UniProt, KEGG pathways), interactions (STRING), co-expression (ATTED-II/BAR), literature
+  (Europe PMC), and BLAST results — in single-locus, parallel-batch, and cross-source synthesis
+  variants. All tools publish JSON output schemas and EDAM ontology tags.
+
+codeRepository: https://github.com/musharna/plant-genomics-mcp
+
+url: https://pypi.org/project/plant-genomics-mcp/
+
+softwareHelp:
+  "@type": CreativeWork
+  name: README and usage documentation
+  url: https://github.com/musharna/plant-genomics-mcp#readme
+
+maintainer:
+  - "@type": Person
+    name: musharna
+    identifier: musharna
+    url: https://github.com/musharna
+
+license: https://spdx.org/licenses/MIT.html
+
+applicationCategory: ReferenceApplication
+
+keywords:
+  - plant-genomics
+  - genomics
+  - ensembl-plants
+  - uniprot
+  - kegg
+  - string-db
+  - gene-annotation
+  - bioinformatics
+  - functional-genomics
+  - research-data
+
+datePublished: "2026-05-30"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - 32 tools across 11 backends (Ensembl Plants, Phytozome, UniProtKB, Europe PMC, QuickGO, NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, BAR)
+  - Single-locus, parallel-batch, and cross-source synthesis variants
+  - Organism resolution by slug, scientific name, common name, or NCBI taxid
+  - Functional annotation (GO, UniProt, KEGG), interactions (STRING), and co-expression (ATTED-II/BAR)
+  - JSON output schemas and EDAM ontology tags on every tool


### PR DESCRIPTION
Name: Plant Genomics MCP

Description: A Model Context Protocol server providing 32 tools for plant-genomics locus lookup across 11 free public backends (Ensembl Plants, Phytozome BioMart, UniProtKB, Europe PMC, QuickGO, NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, BAR), with single-locus, parallel-batch, and cross-source synthesis variants.

Adds `servers/musharna-plant-genomics-mcp/meta.yaml`.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: `id` is unique and follows `https://github.com/<github_user>/<repository_name>` (`https://github.com/musharna/plant-genomics-mcp`)
- [x] **Schema Compliance**: `meta.yaml` validated with `jsonschema` against the repo's `schema.json`.
- [x] **Repository Access**: Publicly accessible (https://github.com/musharna/plant-genomics-mcp)
- [x] **Documentation Access**: README at repo root is public.
- [x] **Biomedical Relevance**: Plant **functional**-genomics server. Its biomedical relevance is via the shared molecular-biology resources it queries and synthesizes — UniProtKB (protein function), KEGG (pathways), STRING-DB (interactions), QuickGO/GO (ontology), Europe PMC (literature), NCBI BLAST — and via comparative/translational plant↔human genomics. _Note for maintainers:_ the primary domain is plant biology; flagging this openly in case it falls outside the registry's biomedical scope — happy to withdraw if it's not a fit.
- [x] **Open Source License**: MIT (https://spdx.org/licenses/MIT.html)
- [x] **Search Discoverability**: Keywords cover plant-genomics, genomics, ensembl-plants, uniprot, kegg, string-db, gene-annotation, bioinformatics, functional-genomics, research-data.
- [x] **Free Academic Usage**: All 11 backends are free public APIs; the server adds no paywall.
- [x] **Non-Duplication**: No existing registry server covers plant-genomics locus lookup across Ensembl Plants / Phytozome / Gramene with cross-source synthesis.
- [x] **MCP Compliance**: Implements the MCP spec (stdio); on the official MCP registry as `io.github.musharna/plant-genomics-mcp` and on PyPI as `plant-genomics-mcp`. Tools publish JSON output schemas + EDAM ontology tags.
- [x] **Installation Instructions**: `pipx install plant-genomics-mcp` (also Docker via GHCR); documented in README.
- [x] **Maintained**: Actively maintained; released v1.8.0.
- [x] **Functionality Testing**: CI test suite with codecov; all tools tested.
