### PR TITLE
Add dna-seq/just-prs-mcp to registry

### DIFF
--- a/servers/dna-seq-just-prs-mcp/meta.yaml
+++ b/servers/dna-seq-just-prs-mcp/meta.yaml
@@ -1,0 +1,53 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/dna-seq/just-prs-mcp
+
+identifier: dna-seq/just-prs-mcp
+
+name: just-prs-mcp
+
+description: >
+  An MCP server for polygenic risk score computation, wrapping the just-prs
+  library and PGS Catalog. Provides PGS Catalog search, VCF normalization,
+  PRS computation, percentile and absolute risk analysis, quality assessment,
+  batch scoring, by-trait reports, and sample genome download.
+
+codeRepository: https://github.com/dna-seq/just-prs-mcp
+
+maintainer:
+  - "@type": Person
+    name: Anton Kulaga
+    identifier: antonkulaga
+    url: https://github.com/antonkulaga
+
+license: https://spdx.org/licenses/MIT.html
+
+applicationCategory: HealthApplication
+
+keywords:
+  - polygenic risk score
+  - prs
+  - pgs-catalog
+  - genomics
+  - vcf
+  - bioinformatics
+  - genetics
+  - precision medicine
+  - risk assessment
+  - longevity
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - PGS Catalog search and score lookup
+  - VCF normalization to Parquet
+  - Polygenic risk score computation
+  - Batch PRS computation across multiple scores
+  - Per-trait PRS reports
+  - Percentile ranking against reference populations
+  - Absolute risk estimation
+  - Quality assessment of computed scores
+  - Sample genome download for testing
+  - Prevalence and epidemiological data lookup
+  - Reference panel scoring (Linux/WSL)


### PR DESCRIPTION
## Summary

Adding [just-prs-mcp](https://github.com/dna-seq/just-prs-mcp) — an MCP server for polygenic risk score (PRS) computation, wrapping the [just-prs](https://pypi.org/project/just-prs/) library and the PGS Catalog. It provides PGS Catalog search, VCF normalization, PRS computation, percentile/absolute-risk/quality analysis, batch scoring, by-trait reports, and a sample genome download for users without their own VCF.

## MCP Server Submission Checklist

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/dna-seq/just-prs-mcp`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible (README in the repository)
- [x] **Biomedical Relevance**: The MCP server computes polygenic risk scores from personal genomic data (VCF files) using the PGS Catalog, enabling genomic risk assessment for diseases and traits — directly applicable to precision medicine and genomic research.
- [x] **Open Source License**: The server is released under the MIT license
- [x] **Search Discoverability**: The description and tags cover polygenic risk scores, PRS, PGS Catalog, genomics, VCF, bioinformatics, genetics, precision medicine, risk assessment, and longevity
- [x] **Free Academic Usage**: The server and all its dependencies (just-prs, PGS Catalog) are free for academic research
- [x] **Non-Duplication**: No existing BioContextAI registry server provides polygenic risk score computation or PGS Catalog access
- [x] **MCP Compliance**: The server implements the Model Context Protocol via FastMCP, with typed tools and structured responses
- [x] **Installation Instructions**: Clear instructions are provided in the README (pip/uv install, Docker, Smithery deployment)
- [x] **Maintained**: The project is actively maintained (latest release: just-prs 0.4.9)
- [x] **Functionality Testing**: All tools have been tested via unit tests and manual testing with real VCF data

🤖 Generated with [Claude Code](https://claude.com/claude-code)