### PR TITLE
Add scvi-tools mcp to registry

### DIFF
--- a/servers/YosefLab-scvi-tools-mcp/mcp.json
+++ b/servers/YosefLab-scvi-tools-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "YosefLab/scvi-tools-mcp": {
+      "command": "uvx",
+      "args": ["scvi-tools-mcp"]
+    }
+  }
+}

--- a/servers/YosefLab-scvi-tools-mcp/meta.yaml
+++ b/servers/YosefLab-scvi-tools-mcp/meta.yaml
@@ -1,0 +1,55 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/YosefLab/scvi-tools-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: YosefLab/scvi-tools-mcp
+
+name: scvi-tools mcp
+
+description: >
+  An MCP (Model Context Protocol) server for deep probabilistic analysis of single-cell omics data using scvi-tools, which gives LLMs structured access to scvi-tools knowledge: model documentation, tutorials, API reference, workflow templates, pretrained Hugging Face Hub models, and community FAQ.
+  No runtime model execution — pure knowledge layer. Works with Claude Desktop, Cursor, and any MCP-compatible client.
+
+codeRepository: https://github.com/YosefLab/scvi-tools-mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://scvi-tools-mcp.readthedocs.io/en/latest/index.html
+  name: Documentation
+
+maintainer:
+  - "@type": Organization
+    name: YosefLab
+    identifier: YosefLab
+    url: https://github.com/YosefLab
+  - "@type": Person
+    name: Ori Kronfeld
+    identifier: ori-kron-wis
+    url: https://github.com/ori-kron-wis
+
+license: https://spdx.org/licenses/BSD-3-Clause.html
+
+applicationCategory: HealthApplication
+
+keywords:
+  - scvi-tools
+  - single-cell
+  - scvi
+  - bioinformatics
+  - machine-learning
+  - variational-inference
+  - deep-learning
+  - vae
+  - scrna-seq
+  - scverse
+
+datePublished: "2026-06-10"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python


### PR DESCRIPTION
Name: scvi-tools mcp

Description: An MCP (Model Context Protocol) server for deep probabilistic analysis of single-cell omics data using scvi-tools, which gives LLMs structured access to scvi-tools knowledge: model documentation, tutorials, API reference, workflow templates, pretrained Hugging Face Hub models, and community FAQ.
No runtime model execution — pure knowledge layer. Works with Claude Desktop, Cursor, and any MCP-compatible client.

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: The MCP server provides specific tools for biomedical research or clinical activities (please briefly describe)
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [x] **Free Academic Usage**: The services exposed through the MCP server are free for academic research
- [x] **Non-Duplication**: This is not a fully duplicate effort of an existing BioContextAI registry MCP server (if similar to another server, please explain the unique aspects)
- [x] **MCP Compliance**: The server properly implements the Model Context Protocol specification
- [x] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: The project is not abandoned
- [x] **Functionality Testing**: All exposed tools and resources have been tested and function as expected (manual or unit tests)