### PR TITLE
Add GWAS Catalog MCP server to registry

### DIFF
--- a/servers/ebispot-gwas-mcp/mcp.json
+++ b/servers/ebispot-gwas-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ebispot/gwas-mcp": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://ebi.ac.uk/gwas/mcp"]
+    }
+  }
+}

--- a/servers/ebispot-gwas-mcp/meta.yaml
+++ b/servers/ebispot-gwas-mcp/meta.yaml
@@ -1,0 +1,49 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/EBISPOT/gwas-mcp/
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: ebispot/gwas-mcp
+
+name: GWAS Catalog MCP server
+
+description: >
+  GWAS Catalog Model Context Protocol server, supporting natural language queries of associations, studies, and traits
+
+codeRepository: https://github.com/EBISPOT/gwas-mcp
+
+url: https://ebi.ac.uk/gwas/mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://github.com/EBISPOT/gwas-mcp#readme
+  name: Documentation
+
+maintainer:
+  - "@type": Person
+    name: Benjamin Wingfield
+    identifier: nebfield
+    url: https://github.com/nebfield
+
+license: https://spdx.org/licenses/Apache-2.0.html
+
+applicationCategory: HealthApplication
+
+keywords:
+  - knowledgebase
+  - gwas
+  - genomics
+  - gwas catalog
+
+datePublished: "2026-07-01"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - gwas catalog


### PR DESCRIPTION
Name: GWAS Catalog MCP server

Description: GWAS Catalog Model Context Protocol server, supporting natural language queries of associations, studies, and traits 

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: The MCP server provides specific tools for biomedical research or clinical activities (please briefly describe)
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [x] **Free Academic Usage**: The services exposed through the MCP server are free for academic research
- [x] **Non-Duplication**: This is not a fully duplicate effort of an existing BioContextAI registry MCP server (if similar to another server, please explain the unique aspects)
- [x] **MCP Compliance**: The server properly implements the Model Context Protocol specification
- [x] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: The project is not abandoned
- [x] **Functionality Testing**: All exposed tools and resources have been tested and function as expected (manual or unit tests)