### PR TITLE
Add Drosophila Stocks MCP to registry

### DIFF
--- a/servers/neurorishika-drosophila-stocks-mcp/mcp.json
+++ b/servers/neurorishika-drosophila-stocks-mcp/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "neurorishika/drosophila-stocks-mcp": {
+      "command": "uvx",
+      "args": ["drosophila-stocks-mcp"],
+      "env": {
+        "UV_PYTHON": "3.12"
+      }
+    }
+  }
+}

--- a/servers/neurorishika-drosophila-stocks-mcp/meta.yaml
+++ b/servers/neurorishika-drosophila-stocks-mcp/meta.yaml
@@ -1,0 +1,45 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/neurorishika/drosophila-stocks-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: neurorishika/drosophila-stocks-mcp
+
+name: Drosophila Stocks MCP
+
+description: >
+  An MCP server that lets AI assistants query Drosophila melanogaster stock centers — Bloomington (BDSC), Kyoto/DGRC, Vienna (VDRC), Korea (KDRC), NIG-FLY, FlyORF, and the National Drosophila Species Stock Center (NDSSC) — by genotype or by gene, using FlyBase's freely redistributable data. FlyBase already integrates the stock records (genotype, stock number, holding center) for all of these collections. This server indexes that bulk data locally for fast search and generates deep links into each center's own ordering system for the parts FlyBase does not track (live availability, price, shipping).
+
+codeRepository: https://github.com/neurorishika/drosophila-stocks-mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://github.com/neurorishika/drosophila-stocks-mcp#readme
+  name: Documentation
+
+maintainer:
+  - "@type": Person
+    name: Rishika Mohanta
+    identifier: neurorishika
+    url: https://github.com/neurorishika
+
+license: https://spdx.org/licenses/MIT.html
+
+applicationCategory: UtilitiesApplication
+
+keywords:
+  - Drosophila
+  - Fruit fly
+  - Flywork
+  - Genetics
+  - Stocks
+
+datePublished: "2026-07-02"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python


### PR DESCRIPTION
Name: Drosophila Stocks MCP

Description: An MCP server that lets AI assistants query Drosophila melanogaster stock centers — Bloomington (BDSC), Kyoto/DGRC, Vienna (VDRC), Korea (KDRC), NIG-FLY, FlyORF, and the National Drosophila Species Stock Center (NDSSC) — by genotype or by gene, using FlyBase's freely redistributable data. FlyBase already integrates the stock records (genotype, stock number, holding center) for all of these collections. This server indexes that bulk data locally for fast search and generates deep links into each center's own ordering system for the parts FlyBase does not track (live availability, price, shipping).

Please complete the following checklist before submitting your pull request:

- [x] **Unique Identifier**: The `id` field is unique and follows the format `https://github.com/<github_user>/<repository_name>`
- [x] **Schema Compliance**: The `meta.yaml` file fully complies with the schema defined in `schema.json`. I have run the `pre-commit` hook to confirm.
- [x] **Repository Access**: The source code repository URL is publicly accessible
- [x] **Documentation Access**: The documentation URL is publicly accessible
- [x] **Biomedical Relevance**: Wet-lab Drosophila genetics research depends on locating and ordering the correct genetically-defined fly stock (a specific genotype/allele/transgene combination) from one of several international stock centers. This server makes that stock-discovery step queryable by an AI assistant — search by genotype substring or by gene (symbol/synonym/FBgn, resolved via FlyBase's own bulk synonym data) across BDSC, Kyoto/DGRC, VDRC, KDRC, NIG-FLY, FlyORF, and NDSSC, then generates a direct deep link into that center's own ordering system for the specific stock found.
- [x] **Open Source License**: The server is released under one of the [OSI-approved](https://opensource.org/license) licenses listed in the schema (MIT)
- [x] **Search Discoverability**: The description and tags enable relevant search queries to find the MCP server
- [x] **Free Academic Usage**: All data (FlyBase's bulk stock/synonym files and REST API) is free for academic use, and the MCP server itself only performs read-only queries against this data plus generates links to each center's public ordering page — no paid API or service is required to use any of the tools this server exposes.
- [x] **Non-Duplication**: I checked the existing registry and found one related entry, `sviatkh/flybase-mcp-server`, but it has no functional overlap: it exposes exactly two tools for looking up a gene's FlyBase summary and GO-slim terms by FBgn ID. This server is entirely about a different task — finding and ordering physical fly *stocks* (not gene annotations) across seven different stock centers by genotype or gene, backed by FlyBase's separate bulk stock-list data rather than gene records.
- [x] **MCP Compliance**: Verified with this repository's own `src/schema_validation/get_mcp_tools.py` validator against the submitted `mcp.json`, which launches the real published package via `uvx` and confirms all 6 tools list correctly with valid schemas. Also independently tested with the MCP Inspector and the official `mcp` Python SDK's `ClientSession` over both `stdio` and `streamable-http` transports.
- [x] **Installation Instructions**: Clear instructions for installing and running the server are provided
- [x] **Maintained**: Actively maintained; this submission is being made alongside the initial 0.1.1 release.
- [x] **Functionality Testing**: 73 offline unit/integration tests plus 11 tests against live FlyBase and live stock-center endpoints (including rendered-page-content checks on every order-URL deep link, not just HTTP status) all pass. See `tests/` in the [source repository](https://github.com/neurorishika/drosophila-stocks-mcp).