### PR TITLE
Update plant-genomics-mcp entry: 32→50 tools, 11→23 backends

### DIFF
--- a/servers/musharna-plant-genomics-mcp/meta.yaml
+++ b/servers/musharna-plant-genomics-mcp/meta.yaml
@@ -10,18 +10,19 @@ identifier: musharna/plant-genomics-mcp
 name: Plant Genomics MCP
 
 description: >
-  A Model Context Protocol server providing 32 tools for plant-genomics locus lookup across 11
+  A Model Context Protocol server providing 50 tools for plant-genomics locus lookup across 23
   free public backends: Ensembl Plants, Phytozome BioMart, UniProtKB, Europe PMC, QuickGO,
-  NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, and the Bio-Analytic Resource for Plant Biology.
-  Tools take a TAIR-style locus (e.g. AT1G01010) plus an optional organism (slug, scientific name,
-  common name, or NCBI taxid) and return gene metadata, protein and functional annotation (GO,
-  UniProt, KEGG pathways), interactions (STRING), co-expression (ATTED-II/BAR), literature
-  (Europe PMC), and BLAST results — in single-locus, parallel-batch, and cross-source synthesis
-  variants. All tools publish JSON output schemas and EDAM ontology tags.
+  Planteome, PlantCyc/PMN, g:Profiler, AlphaFold DB, PDBe, InterPro, JASPAR, PANTHER, OrthoDB,
+  AraGWAS, 1001 Genomes, NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, ThaleMine, and the
+  Bio-Analytic Resource for Plant Biology. Tools take a TAIR-style locus (e.g. AT1G01010) plus an
+  optional organism (slug, scientific name, common name, or NCBI taxid) and return gene metadata
+  and sequence, protein structure and domains, functional annotation (GO, UniProt, KEGG,
+  PlantCyc, Plant/Trait Ontology), gene-set enrichment, transcription-factor binding motifs,
+  orthology, interactions, co-expression, natural variation and GWAS, literature, and BLAST
+  results — in single-locus, parallel-batch, and cross-source synthesis variants. All tools
+  publish JSON output schemas, MCP tool annotations, and EDAM ontology tags.
 
 codeRepository: https://github.com/musharna/plant-genomics-mcp
-
-url: https://pypi.org/project/plant-genomics-mcp/
 
 softwareHelp:
   "@type": CreativeWork
@@ -41,14 +42,14 @@ applicationCategory: ReferenceApplication
 keywords:
   - plant-genomics
   - genomics
+  - arabidopsis
   - ensembl-plants
   - uniprot
   - kegg
-  - string-db
+  - protein-structure
   - gene-annotation
-  - bioinformatics
   - functional-genomics
-  - research-data
+  - bioinformatics
 
 datePublished: "2026-05-30"
 
@@ -59,8 +60,12 @@ programmingLanguage:
   - Python
 
 featureList:
-  - 32 tools across 11 backends (Ensembl Plants, Phytozome, UniProtKB, Europe PMC, QuickGO, NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, BAR)
+  - 50 tools across 23 backends (Ensembl Plants, Phytozome, UniProtKB, Europe PMC, QuickGO, Planteome, PlantCyc/PMN, g:Profiler, AlphaFold, PDBe, InterPro, JASPAR, PANTHER, OrthoDB, AraGWAS, 1001 Genomes, NCBI BLAST, Gramene, KEGG, STRING-DB, ATTED-II, ThaleMine, BAR)
   - Single-locus, parallel-batch, and cross-source synthesis variants
   - Organism resolution by slug, scientific name, common name, or NCBI taxid
-  - Functional annotation (GO, UniProt, KEGG), interactions (STRING), and co-expression (ATTED-II/BAR)
-  - JSON output schemas and EDAM ontology tags on every tool
+  - Protein structure and domain architecture (AlphaFold, PDBe, InterPro) and transcription-factor binding motifs (JASPAR)
+  - Natural variation, variant effect prediction, and GWAS associations (Ensembl VEP, AraGWAS, 1001 Genomes)
+  - Functional annotation (GO, UniProt, KEGG, PlantCyc, Plant/Trait Ontology) and gene-set enrichment (g:Profiler)
+  - Predicted and experimental interactions (STRING, ThaleMine/BioGRID/IntAct) and co-expression (ATTED-II/BAR)
+  - JSON output schemas, MCP tool annotations, and EDAM ontology tags on every tool
+  - stdio and Streamable HTTP transports; published to PyPI, GHCR, and the official MCP registry


### PR DESCRIPTION
**This updates an existing entry — it is not a new server submission.** `plant-genomics-mcp` has been in the Registry since 2026-05-30, but the entry was written against server v1.8.0 and never refreshed. The server is now v1.18.2, so the public catalog has been advertising **32 tools across 11 backends** against an actual **50 tools across 23 backends** — under half its real coverage.

## Changes

- **`description` + `featureList`:** 32 → 50 tools, 11 → 23 backends. Backends added since the original entry: Planteome (Plant/Trait Ontology), PlantCyc/PMN, g:Profiler, AlphaFold DB, PDBe, InterPro, JASPAR, PANTHER, OrthoDB, AraGWAS, 1001 Genomes, ThaleMine.
- **Removed `url:`.** `schema.json` defines it as _"URL of the remotely hosted MCP server (if available)"_, but the entry pointed it at the PyPI project page, which is not a hosted MCP endpoint. There is no public hosted endpoint for this server, so the field is now omitted rather than misused. (It was being dropped from the published `registry.json` anyway.)
- **`keywords`:** swapped `string-db` (a single backend) and `research-data` (generic) for `arabidopsis` and `protein-structure` — the server's primary model organism and its newer structure/domain tier. Still 10/10.

No change to `@id`, `identifier`, `codeRepository`, `maintainer`, `license`, or `datePublished`.

## Submission Checklist

- [x] **Unique Identifier**: `@id` is `https://github.com/musharna/plant-genomics-mcp` — unchanged from the existing entry.
- [x] **Schema Compliance**: Validated with `check-jsonschema` 0.33.0 against `schema.json` (the `meta.yaml` pre-commit hook) → `ok -- validation done`. Caught two constraint violations while drafting (`keywords` maxItems 10, `description` maxLength 1000); both resolved.
- [x] **Repository Access**: <https://github.com/musharna/plant-genomics-mcp> is public.
- [x] **Documentation Access**: <https://github.com/musharna/plant-genomics-mcp#readme> is public.
- [x] **Biomedical Relevance**: Plant functional genomics. Given a locus identifier (e.g. `AT1G01010`) it returns gene structure and sequence, protein structure/domains (AlphaFold, PDBe, InterPro), functional annotation (GO, UniProt, KEGG, PlantCyc, Plant/Trait Ontology), gene-set enrichment, TF binding motifs (JASPAR), orthology (Gramene, OrthoDB, PANTHER), predicted and experimental protein interactions (STRING, ThaleMine/BioGRID/IntAct), co-expression (ATTED-II, BAR), natural variation and GWAS (Ensembl VEP, AraGWAS, 1001 Genomes), and literature (Europe PMC) — for 12 curated crop and model species.
- [x] **Open Source License**: MIT (`https://spdx.org/licenses/MIT.html`).
- [x] **Search Discoverability**: Description and keywords updated; `arabidopsis` added, which was previously missing on a server whose primary organism is _Arabidopsis thaliana_.
- [x] **Free Academic Usage**: All 23 backends are free public APIs. Nothing is behind a paid subscription.
- [x] **Non-Duplication**: This is an update to our own existing entry. The server remains the only plant-focused entry in the Registry.
- [x] **MCP Compliance**: stdio and Streamable HTTP transports; structured output (`outputSchema`) on all 50 tools; MCP resources and prompts; tool annotations (`readOnlyHint`/`openWorldHint`) on every tool. Also published to the official MCP registry as `io.github.musharna/plant-genomics-mcp`.
- [x] **Installation Instructions**: `uvx plant-genomics-mcp`, `pipx install plant-genomics-mcp`, or the GHCR container — all in the README.
- [x] **Maintained**: Actively maintained; v1.18.2 released 2026-07-24.
- [x] **Functionality Testing**: 720 unit tests plus live-API integration tests, 95.7% coverage, CI across Python 3.11–3.14.
