### PR TITLE
Add Ask Helena

### DIFF
--- a/servers/helena-bioinformatics-ask-helena-mcp/mcp.json
+++ b/servers/helena-bioinformatics-ask-helena-mcp/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "helena-bioinformatics/ask-helena-mcp": {
+      "url": "https://api.helena.bio/ask/v1/mcp"
+    }
+  }
+}

--- a/servers/helena-bioinformatics-ask-helena-mcp/meta.yaml
+++ b/servers/helena-bioinformatics-ask-helena-mcp/meta.yaml
@@ -17,6 +17,8 @@ description: >
 
 codeRepository: https://github.com/helena-bioinformatics/ask-helena-mcp
 
+url: https://api.helena.bio/ask/v1/mcp
+
 softwareHelp:
   "@type": CreativeWork
   url: https://www.helena.bio/ask
@@ -30,7 +32,7 @@ maintainer:
 
 license: https://spdx.org/licenses/Apache-2.0.html
 
-applicationCategory: ScienceApplication
+applicationCategory: ReferenceApplication
 
 keywords:
   - Helena Bioinformatics

--- a/servers/helena-bioinformatics-ask-helena-mcp/meta.yaml
+++ b/servers/helena-bioinformatics-ask-helena-mcp/meta.yaml
@@ -1,0 +1,53 @@
+"@context": https://schema.org
+"@type": SoftwareApplication
+"@id": https://github.com/helena-bioinformatics/ask-helena-mcp
+
+additionalType:
+  - https://schema.org/SoftwareSourceCode
+
+identifier: helena-bioinformatics/ask-helena-mcp
+
+name: Ask Helena
+
+description: >
+  Ask Helena is the official public, read-only MCP server from Helena Bioinformatics for questions
+  about Helena Bioinformatics and its published products. It searches an approved public corpus and
+  returns grounded answers or bounded evidence with traceable sources. It excludes private content,
+  patient data and clinical records and does not perform live clinical variant interpretation.
+
+codeRepository: https://github.com/helena-bioinformatics/ask-helena-mcp
+
+softwareHelp:
+  "@type": CreativeWork
+  url: https://www.helena.bio/ask
+  name: Ask Helena public website
+
+maintainer:
+  - "@type": Organization
+    name: Helena Bioinformatics
+    identifier: helena-bioinformatics
+    url: https://github.com/helena-bioinformatics
+
+license: https://spdx.org/licenses/Apache-2.0.html
+
+applicationCategory: ScienceApplication
+
+keywords:
+  - Helena Bioinformatics
+  - Public Knowledge
+  - Bioinformatics
+  - Source Citations
+  - Documentation
+  - MCP
+
+datePublished: "2026-08-14"
+
+operatingSystem:
+  - Cross-platform
+
+programmingLanguage:
+  - Python
+
+featureList:
+  - search_public_knowledge
+  - ask_public_knowledge


### PR DESCRIPTION
## Summary

Adds **Ask Helena**, the official Helena Bioinformatics public knowledge MCP, as a separate registry entry.

The metadata uses the canonical identity:

- Publisher: Helena Bioinformatics
- Registry: `io.github.helena-bioinformatics/ask-helena` version `1.0.4`
- Source: https://github.com/helena-bioinformatics/ask-helena-mcp
- Hosted endpoint: https://api.helena.bio/ask/v1/mcp
- Website: https://www.helena.bio/ask
- Tools: `search_public_knowledge`, `ask_public_knowledge`

Ask Helena is public and read-only. It answers questions about Helena Bioinformatics and its published bioinformatics products with source citations. It excludes private content, backend details, patient data, clinical records and writes and does not perform live variant classification.

The Apache-2.0 license applies only to the public integration bridge. The private backend and corpus remain unpublished and proprietary. This additive entry does not modify or replace the Folklore submission.