### PR TITLE
Update ToolUniverse entry: 211 tools -> 2,600+, fix documentation URL, expand featureList

### DIFF
--- a/servers/mims-harvard-ToolUniverse/meta.yaml
+++ b/servers/mims-harvard-ToolUniverse/meta.yaml
@@ -7,16 +7,22 @@ identifier: mims-harvard/ToolUniverse
 name: ToolUniverse
 
 description: >
-  ToolUniverse is a collection of biomedical tools designed for use by Agentic AI. It is a critical component
-  of TxAgent, providing the agent with the ability to access and leverage a vast array of biomedical knowledge
-  to solve complex therapeutic reasoning tasks. ToolUniverse includes 211 biomedical tools that address
-  various aspects of drugs and diseases.
+  ToolUniverse is a collection of biomedical and scientific tools designed for use by Agentic AI,
+  usable as a Python SDK or as an MCP server. It originated as the tool layer behind TxAgent and
+  now provides a standalone catalog that a default install loads as more than 2,600 tools. Coverage
+  spans drug and target data (OpenFDA drug labelling and adverse events, ChEMBL, Open Targets,
+  PubChem, DailyMed, RxNorm), clinical evidence (ClinicalTrials.gov), genomics and proteomics
+  (Ensembl, UniProt, Human Protein Atlas, RCSB PDB/PDBe, GWAS Catalog, AlphaFold), pathway and
+  enrichment analysis (Reactome, KEGG, Enrichr), phenotype and disease ontologies (Monarch
+  Initiative, HPO, EFO, Orphanet), and literature retrieval (PubMed, Europe PMC, OpenAlex,
+  Semantic Scholar, bioRxiv/medRxiv), alongside agentic, machine-learning, and scientific
+  software-package tools.
 
 codeRepository: https://github.com/mims-harvard/ToolUniverse
 
 softwareHelp:
   "@type": CreativeWork
-  url: https://zitniklab.hms.harvard.edu/TxAgent/
+  url: https://zitniklab.hms.harvard.edu/ToolUniverse/
   name: Documentation
 
 maintainer:
@@ -32,11 +38,25 @@ applicationCategory: HealthApplication
 keywords:
   - TxAgent
   - ToolUniverse
+  - drug-discovery
+  - clinical-trials
+  - genomics
+  - proteomics
+  - pathway-analysis
+  - literature-search
+  - pharmacovigilance
+  - rare-disease
 
 featureList:
-  - FDA
-  - Open Targets
-  - Monarch Initiative
+  - 2600+ tools loaded by default, exposed through a Python SDK and an MCP server (stdio and HTTP transports)
+  - Drug and target data (OpenFDA drug labelling and adverse events, ChEMBL, Open Targets, PubChem, DailyMed, RxNorm, FDA Orange Book, FDA GSRS)
+  - Clinical evidence and safety (ClinicalTrials.gov, FAERS analytics, CDC and NHANES population data)
+  - Genomics and proteomics (Ensembl, UniProt, Human Protein Atlas, RCSB PDB and PDBe, GWAS Catalog, AlphaFold, AlphaMissense, CELLxGENE Census)
+  - Pathway, network, and enrichment analysis (Reactome, KEGG, Enrichr, STRING, HumanBase, DepMap)
+  - Phenotype and disease ontologies (Monarch Initiative, HPO, EFO, Orphanet, DisGeNET)
+  - Literature and preprint retrieval (PubMed, Europe PMC, OpenAlex, Semantic Scholar, CrossRef, arXiv, bioRxiv/medRxiv, PubTator)
+  - Tool discovery for large catalogs via tool finders and compact mode, which exposes a handful of discovery tools instead of the full catalog
+  - Agentic tools, machine-learning model wrappers, and scientific software-package tools
 
 datePublished: "2025-07-13"
 


### PR DESCRIPTION
Name: ToolUniverse

Description: Updates the existing `servers/mims-harvard-ToolUniverse/meta.yaml` entry. This is **not** a new server submission — it refreshes a listing that has drifted substantially from the upstream project.

## What changed

**1. Tool count: 211 → "more than 2,600"**

The entry has understated the catalog by roughly an order of magnitude. Rather than copy a figure, I installed the current release and ran the loader:

```
ToolUniverse().load_tools()  # v1.4.1
Number of tools after load tools: 2602
```

For transparency, three other candidate numbers were considered and rejected:

| Number | Source | Why not used |
|---|---|---|
| 610 | JSON files in `src/tooluniverse/data/` | file count, not tool count |
| 775 | ToolUniverse issue #518 | from the packaged `tooluniverse-mcp-native` 1.0.15 desktop bundle, since superseded by 1.4.1 |
| 2,741 | tool configs in those files | environment-dependent upward |

The 610 files define 2,741 configs (2,739 unique names); the runtime loads 2,602 because 137 LLM-backed `AgenticTool` entries are skipped without model API keys. I used "more than 2,600" because it is a floor any reviewer reproduces on a clean install.

**2. `softwareHelp.url` corrected**

Pointed at `https://zitniklab.hms.harvard.edu/TxAgent/` — a different project. Now points at the ToolUniverse documentation site. Both URLs return 200; the old one was simply the wrong target.

**3. `featureList` expanded from 3 entries to 9 domain-grouped bullets**

Previously listed only `FDA`, `Open Targets`, and `Monarch Initiative`. Every resource now named was verified present as a loaded tool category, with counts: OpenFDA 199, Open Targets 71, Ensembl 53, literature 40, Reactome 38, UniProt 34, PubChem 33, ChEMBL 29, KEGG 26, Monarch/HPO 22, ClinicalTrials.gov 16, plus Orphanet, AlphaFold, AlphaMissense, CELLxGENE, DepMap, STRING and DisGeNET.

**4. `keywords` expanded from 2 to 10** (schema maximum), since two keywords is thin discoverability for a catalog of this size.

The description also drops the "a critical component of TxAgent" framing in favour of noting that ToolUniverse originated as TxAgent's tool layer and is now a standalone catalog. Description is 857 characters against the schema's 1000 limit.

Unchanged: `@id`, `identifier`, `codeRepository`, `maintainer`, `license`, `datePublished`, and `mcp.json`.

This follows the shape of #61 (`Update plant-genomics-mcp entry: 32→50 tools, 11→23 backends`).

## Checklist

- [x] **Unique Identifier**: unchanged from the existing entry
- [x] **Schema Compliance**: `check-jsonschema 0.33.0` (the version pinned in `.pre-commit-config.yaml`) → `ok -- validation done`. Full pre-commit run: meta.yaml schema, mcp.json schema, and name/identifier validation all Passed. One caveat: the `prettier` hook could not install in my environment (`npm error EALLOWGIT`, a modern-npm incompatibility with `mirrors-prettier@v4.0.0-alpha.8`, unrelated to this change), so I verified formatting out-of-band with `npx prettier@4.0.0-alpha.8 --check` → `All matched files use Prettier code style!`
- [x] **Repository Access**: https://github.com/mims-harvard/ToolUniverse
- [x] **Documentation Access**: the corrected `softwareHelp` URL returns 200
- [x] **Biomedical Relevance**: unchanged; wraps OpenFDA, ChEMBL, ClinicalTrials.gov, Ensembl, Reactome, KEGG, UniProt, HPO/Monarch and others
- [x] **Open Source License**: Apache-2.0, unchanged
- [x] **Search Discoverability**: the point of the keyword and featureList expansion
- [x] **Free Academic Usage**: unchanged
- [x] **Non-Duplication**: updates an existing entry
- [x] **MCP Compliance**: unchanged
- [x] **Installation Instructions**: unchanged
- [x] **Maintained**: last push 2026-08-13
- [x] **Functionality Testing**: tool counts above come from actually loading the package, not from documentation
